### PR TITLE
clean-activecontrol-on-destroy: clear activecontrol data when wheel c…

### DIFF
--- a/jquery.wheelcolorpicker.js
+++ b/jquery.wheelcolorpicker.js
@@ -1254,6 +1254,15 @@
 		// Reset layout
 		// No need to delete global popup
 		if(this.options.layout == 'block') {
+			// Check if active control is the same widget as destroyed widget, remove the reference if it's true
+			var $control = $( $('body').data('jQWCP.activeControl') ); // Refers to slider wrapper or wheel
+			if ($control.length) {
+				var controlWidget = $control.closest('.jQWCP-wWidget');
+				if ($widget.is(controlWidget)) {
+					$('body').data('jQWCP.activeControl', null);
+				}
+			}
+			
 			$widget.before(this.input);
 			$widget.remove();
 			$input.show();


### PR DESCRIPTION
…olor picker is destroyed to prevent mouse events being redirected to the already destroyed widget.

This may happen when you hold the mouse down on the color wheel picker and the widget is destroyed.