### PR TITLE
Add .gitignore for node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
While it's not required for the included example file, the folder gets created when using npm link.