### PR TITLE
Fixes 'block layout' input value + add 'colorchange' event

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -359,6 +359,17 @@
                 box-sizing: border-box;
             }
         </style>
+
+		<p class='color-preview'>(Select a Color)</p>
+        <script type="text/javascript">
+        $(function() {
+            $('.color-block').on('colorchange',function(e){
+                var color=$(this).find('input').attr('value'); /* .val() dont work on hidden elements*/
+                $('.color-preview').css('background-color','#'+color).html(color);
+            });
+        });
+        </script>
+
 	</div>
 	
 	<div class="snippet-output" data-id="snippet-block"></div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -197,7 +197,7 @@
 	</p>
 	
 	<div id="snippet-header" class="snippet">
-		<script type="text/javascript" src="../jquery.wheelcolorpicker-3.0.5.min.js"></script>
+		<script type="text/javascript" src="../jquery.wheelcolorpicker.js"></script>
 		<link type="text/css" rel="stylesheet" href="../css/wheelcolorpicker.css" />
 	</div>
 	

--- a/jquery.wheelcolorpicker.js
+++ b/jquery.wheelcolorpicker.js
@@ -1703,7 +1703,9 @@
 		
 		// #13 only update if value is different to avoid cursor repositioned to the end of text on some browsers
 		if(this.input.value != this.getValue()) {
-			this.input.value = this.getValue();
+			/* in layout:block mode , because input is *hidden*,  input.value=  does NOT work, while attr('value') does ! */
+			//this.input.value = this.getValue();
+			$input.attr('value',this.getValue());
 		}
 		
 		if( this.options.preview ) {

--- a/jquery.wheelcolorpicker.js
+++ b/jquery.wheelcolorpicker.js
@@ -1706,6 +1706,7 @@
 			/* in layout:block mode , because input is *hidden*,  input.value=  does NOT work, while attr('value') does ! */
 			//this.input.value = this.getValue();
 			$input.attr('value',this.getValue());
+			$input.trigger('colorchange');
 		}
 		
 		if( this.options.preview ) {


### PR DESCRIPTION
Hi, 

When using the WCP in "popup" mode, all works as expected, and ones can easily listen to the 'change' event from the  input element, to handles color changes.

But on the other hand, in 'block' mode, there are some issues:
- the value of the input element is NOT correctly updated (because the element is hidden).
- and the color value is very difficult to listen to, (because hidden elements are not accessible by the usual  "on change" JS listener).

This PR fixes that, by: 
- correctly saving the value (even if input is hidden)
- adding a 'colorchange' event,
- It also displays a 'colorchange' event demo, in the example page
- (It now uses the NON minified JS version to reflect/use the latest JS source, from the example page.)

I hope that you will like it and merge

Anyway Thanks for this wonderful  colorpicker plugin.

Cheers